### PR TITLE
fix: remove uptime metric

### DIFF
--- a/WakaBot.Web/Program.cs
+++ b/WakaBot.Web/Program.cs
@@ -29,7 +29,6 @@ app.MapGet("/metrics", () =>
 {
     using var scope = app.Services.CreateScope();
     StringBuilder sb = new StringBuilder();
-    sb.AppendLine("waka_uptime " + stopwatch.Elapsed);
     sb.AppendLine("waka_memory_usage " + Process.GetCurrentProcess().PrivateMemorySize64);
 
     var database = scope.ServiceProvider.GetService<WakaContext>();


### PR DESCRIPTION
The uptime metric breaks prometheus so removing it is the best way to make my life easier